### PR TITLE
Add a config for coffeescript

### DIFF
--- a/examples/coffeescript/bulk-decaffeinate.config.js
+++ b/examples/coffeescript/bulk-decaffeinate.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  fileFilterFn: path => !path.includes('test/importing/') && !path.includes('documentation'),
+  decaffeinateArgs: ['--keep-commonjs', '--prefer-const', '--enable-babel-constructor-workaround'],
+};

--- a/examples/coffeescript/config.js
+++ b/examples/coffeescript/config.js
@@ -1,0 +1,6 @@
+export default {
+  cloneUrl: 'https://github.com/jashkenas/coffeescript.git',
+  branch: '1.10.0',
+  useDefaultConfig: true,
+  skipTests: true,
+};


### PR DESCRIPTION
This doesn't set up tests yet, and with the way the project is set up, it ends
up running fewer tests that pass, so I added a flag to just skip tests if we
know that they aren't set up right.

Also, we only support CoffeeScript 1.10.0 at the moment, so I added a way to
check out a custom branch when cloning the repo.

This is also the first repo with files that we know we can't convert. We now
detect if there were failures and run decaffeinate on just the successful files
if so.