### PR TITLE
Add a --publish option

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -1,4 +1,6 @@
 export default {
   cloneUrl: 'https://github.com/atom/atom.git',
+  forkUrl: 'git@github.com:decaffeinate-examples/atom.git',
   useDefaultConfig: true,
+  skipTests: true,
 };

--- a/examples/autoprefixer/config.js
+++ b/examples/autoprefixer/config.js
@@ -1,4 +1,5 @@
 export default {
   cloneUrl: 'https://github.com/postcss/autoprefixer.git',
+  forkUrl: 'git@github.com:decaffeinate-examples/autoprefixer.git',
   useDefaultConfig: true,
 };

--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -1,5 +1,6 @@
 export default {
   cloneUrl: 'https://github.com/codecombat/codecombat.git',
+  forkUrl: 'git@github.com:decaffeinate-examples/codecombat.git',
   useDefaultConfig: true,
   skipTests: true,
 };

--- a/examples/coffeelint/config.js
+++ b/examples/coffeelint/config.js
@@ -1,5 +1,6 @@
 export default {
   cloneUrl: 'https://github.com/clutchski/coffeelint.git',
+  forkUrl: 'git@github.com:decaffeinate-examples/coffeelint.git',
   useDefaultConfig: true,
   extraDependencies: [
     'babelify',

--- a/examples/coffeescript/config.js
+++ b/examples/coffeescript/config.js
@@ -1,5 +1,6 @@
 export default {
   cloneUrl: 'https://github.com/jashkenas/coffeescript.git',
+  forkUrl: 'git@github.com:decaffeinate-examples/coffeescript.git',
   branch: '1.10.0',
   useDefaultConfig: true,
   skipTests: true,

--- a/examples/hubot/config.js
+++ b/examples/hubot/config.js
@@ -1,4 +1,5 @@
 export default {
   cloneUrl: 'https://github.com/github/hubot.git',
+  forkUrl: 'git@github.com:decaffeinate-examples/hubot.git',
   useDefaultConfig: true,
 };


### PR DESCRIPTION
By adding `--publish` to the result, the tool will now add the decaffeinate fork
as a remote and force-push a decaffeinate branch with the results. It also
writes a summary of the conversion results to the README. Currently the summary
isn't particularly pretty, but hopefully it can have more useful information in
the future, like number of lines converted.