### PR TITLE
Add conversion and test result badges

### DIFF
--- a/src/downloadFile.js
+++ b/src/downloadFile.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import https from 'https';
+
+export default async function downloadFile(url, dest) {
+  let file = fs.createWriteStream(dest);
+  let response = await new Promise((resolve, reject) => {
+    https.get(url, (response) => {
+      resolve(response);
+    }).on('error', (err) => {
+      reject(err);
+    });
+  });
+  response.pipe(file);
+  await new Promise((resolve, reject) => {
+    file.on('finish', () => {
+      file.close();
+      resolve();
+    });
+    file.on('error', (err) => {
+      reject(err);
+    });
+  });
+}


### PR DESCRIPTION
These badges live in the repo so that other READMEs can link to the file
directly to get a table of conversion status across multiple projects.