### PR TITLE
Clear node_modules before the atom build

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -2,5 +2,5 @@ export default {
   cloneUrl: 'https://github.com/atom/atom.git',
   forkUrl: 'git@github.com:decaffeinate-examples/atom.git',
   useDefaultConfig: true,
-  testCommand: 'script/build && script/test',
+  testCommand: 'rm -rf ./node_modules && script/build && script/test',
 };


### PR DESCRIPTION
When I run the atom build locally, it complains about version mismatches in
node_modules since the build script wants to install that itself. It's a little
non-trivial to change decaffeinate-examples to always leave that up to the
project, so to get things working I'll just get rid of the directory before
running tests.