### PR TITLE
Fail the build when there's a regression

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -3,4 +3,6 @@ export default {
   forkUrl: 'git@github.com:decaffeinate-examples/atom.git',
   useDefaultConfig: true,
   testCommand: 'rm -rf ./node_modules && script/build && script/test',
+  expectConversionSuccess: true,
+  expectTestSuccess: false,
 };

--- a/examples/autoprefixer/config.js
+++ b/examples/autoprefixer/config.js
@@ -2,4 +2,6 @@ export default {
   cloneUrl: 'https://github.com/postcss/autoprefixer.git',
   forkUrl: 'git@github.com:decaffeinate-examples/autoprefixer.git',
   useDefaultConfig: true,
+  expectConversionSuccess: true,
+  expectTestSuccess: true,
 };

--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -3,4 +3,6 @@ export default {
   forkUrl: 'git@github.com:decaffeinate-examples/codecombat.git',
   useDefaultConfig: true,
   skipTests: true,
+  expectConversionSuccess: true,
+  expectTestSuccess: false,
 };

--- a/examples/coffeelint/config.js
+++ b/examples/coffeelint/config.js
@@ -5,4 +5,6 @@ export default {
   extraDependencies: [
     'babelify',
   ],
+  expectConversionSuccess: true,
+  expectTestSuccess: true,
 };

--- a/examples/coffeescript/config.js
+++ b/examples/coffeescript/config.js
@@ -6,4 +6,6 @@ export default {
   // This doesn't cover all tests, just some of them, so don't mark as
   // successful yet.
   testCommand: 'bin/cake test && `exit 1`',
+  expectConversionSuccess: true,
+  expectTestSuccess: false,
 };

--- a/examples/hubot/config.js
+++ b/examples/hubot/config.js
@@ -2,4 +2,6 @@ export default {
   cloneUrl: 'https://github.com/github/hubot.git',
   forkUrl: 'git@github.com:decaffeinate-examples/hubot.git',
   useDefaultConfig: true,
+  expectConversionSuccess: true,
+  expectTestSuccess: true,
 };


### PR DESCRIPTION
Each config can now specify whether it expects conversion and/or tests to
succeed, and the process will exit 1 if it's not met. This should make it easier
to identify regressions.