### PR TITLE
Remove `clean` from atom setup

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -4,7 +4,6 @@ export default {
   useDefaultConfig: true,
   testCommand: `
     set -e
-    script/clean
     script/build --create-debian-package --create-rpm-package --compress-artifacts
     script/test
   `,


### PR DESCRIPTION
Turns out this doesn't work if build has never been called.