### PR TITLE
Replace `run` with a simpler version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "commander": "^2.9.0",
     "eslint": "^3.14.1",
     "eslint-plugin-babel": "^4.0.1",
-    "mz": "^2.6.0",
+    "mz": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,5 @@
     "eslint": "^3.14.1",
     "eslint-plugin-babel": "^4.0.1",
     "mz": "^2.6.0",
-    "pty.js": "^0.3.1"
   }
 }


### PR DESCRIPTION
The previous `run` was fancy in that it tried to produce live output and also
make stdout/stderr available to the JS side afterward, but this added a lot of
complexity, e.g. using pty so the child process will treat us like a terminal,
and the stdout/stderr ended up never being used. The atom tests are failing with
no output, so this should at least reduce the number of variables in figuring
out what's going wrong.