### PR TITLE
Remove strict mode from coffeescript

### DIFF
--- a/examples/coffeescript/.babelrc
+++ b/examples/coffeescript/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": ["env"],
+  "plugins": ["transform-remove-strict-mode"],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/examples/coffeescript/config.js
+++ b/examples/coffeescript/config.js
@@ -3,8 +3,9 @@ export default {
   forkUrl: 'git@github.com:decaffeinate-examples/coffeescript.git',
   branch: '1.10.0',
   useDefaultConfig: true,
-  // This doesn't cover all tests, just some of them, so don't mark as
-  // successful yet.
+  extraDependencies: [
+    'babel-plugin-transform-remove-strict-mode',
+  ],
   testCommand: `
     set -e
     ./node_modules/.bin/babel src -d lib/coffee-script

--- a/src/cli.js
+++ b/src/cli.js
@@ -67,6 +67,12 @@ async function testProject(project, shouldPublish) {
   if (await exists(`${exampleDir}/.eslintrc.js`)) {
     await run(`cp ${exampleDir}/.eslintrc.js ${repoDir}`);
   }
+  if (await exists(`${exampleDir}/.babelrc`)) {
+    await run(`cp ${exampleDir}/.babelrc ${repoDir}`);
+  }
+  if (await exists(`${exampleDir}/package.json`)) {
+    await run(`cp ${exampleDir}/package.json ${repoDir}`);
+  }
 
   process.chdir(repoDir);
 


### PR DESCRIPTION
Some tests end up assigning to read-only properties, so we should just run tests
with strict mode off.

Also copy package.json if necessary, which will be useful later.