### PR TITLE
Disable strict mode for codecombat

### DIFF
--- a/examples/codecombat/babelrc
+++ b/examples/codecombat/babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": ["env"],
+  "plugins": ["transform-remove-strict-mode"],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -2,6 +2,9 @@ export default {
   cloneUrl: 'https://github.com/codecombat/codecombat.git',
   forkUrl: 'git@github.com:decaffeinate-examples/codecombat.git',
   useDefaultConfig: true,
+  extraDependencies: [
+    'babel-plugin-transform-remove-strict-mode',
+  ],
   skipTests: true,
   expectConversionSuccess: true,
   expectTestSuccess: false,


### PR DESCRIPTION
Some test init code was accidentally using `this` in a function called without
any `this` bound.