### PR TITLE
Use /bin/bash instead of /bin/sh for scripts

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -10,7 +10,7 @@ import { spawn } from 'child_process';
 export default function run(command) {
   console.log(`> ${command}`);
   return new Promise((resolve, reject) => {
-    let childProcess = spawn('/bin/sh', ['-c', command], {stdio: 'inherit'});
+    let childProcess = spawn('/bin/bash', ['-c', command], {stdio: 'inherit'});
     childProcess.on('close', code => {
       if (code === 0) {
         resolve();


### PR DESCRIPTION
Looks like these are different in the travis environment and you can use
`source` in bash rather than needing to do `.`.