### PR TITLE
Save exact versions when saving to package.json

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -94,7 +94,7 @@ async function testProject(project, shouldPublish) {
   await run('npm install');
   let dependencies = getDependencies(config);
   if (dependencies.length > 0) {
-    await run(`npm install --save-dev ${dependencies.join(' ')}`);
+    await run(`npm install --save-dev --save-exact ${dependencies.join(' ')}`);
   }
   await run('git add -A');
   await run('git commit -m "Add dependencies and config to prepare for decaffeinate"');


### PR DESCRIPTION
Codecombat needs babel-brunch 6.0.0, not later, but it looks like npm's default
is to add a `^` to the saved version. Use the `--save-exact` flag to avoid this
behavior.