### PR TITLE
Fix babel-polyfill config for codecombat

### DIFF
--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -8,7 +8,6 @@ export default {
   ],
   testCommand: `
     set -e
-    set -x
     export COCO_TRAVIS_TEST=1
     export DISPLAY=:99.0
     if [ -e /etc/init.d/xvfb ]; then

--- a/examples/codecombat/decaffeinate.patch
+++ b/examples/codecombat/decaffeinate.patch
@@ -24,7 +24,7 @@ index 6daa7a2d6..3f3fe14c3 100644
 
      return cb(null, [{ filename: outFile, content: c.html() }], deps);
 diff --git a/config.js b/config.js
-index 561b02868..6595249a8 100644
+index 561b02868..326c23268 100644
 --- a/config.js
 +++ b/config.js
 @@ -73,7 +73,7 @@ exports.config = {
@@ -64,31 +64,33 @@ index 561b02868..6595249a8 100644
            regJoin('^vendor/scripts/Box2dWeb-2.1.a.3'),
            regJoin('^vendor/scripts/string_score.js'),
            regJoin('^bower_components/underscore.string'),
-@@ -152,6 +152,7 @@ exports.config = {
-           regJoin(`^vendor/scripts/(?!(Box2d|coffeescript|difflib|diffview|jasmine|co|${gameLibraries}))`),
+@@ -149,7 +149,7 @@ exports.config = {
+
+         // - vendor.js, all the vendor libraries
+         'javascripts/vendor.js': [
+-          regJoin(`^vendor/scripts/(?!(Box2d|coffeescript|difflib|diffview|jasmine|co|${gameLibraries}))`),
++          regJoin(`^vendor/scripts/(?!(Box2d|coffeescript|difflib|diffview|jasmine|polyfill|co|${gameLibraries}))`),
            regJoin(`^bower_components/(?!(aether|d3|treema|three.js|esper.js|jquery-ui|${gameLibraries}))`),
            'bower_components/treema/treema-utils.js',
-+          'node_modules/babel-polyfill/polyfill.js',
+         ],
+@@ -161,7 +161,7 @@ exports.config = {
          ],
 
-         'javascripts/game-libraries.js': [
-@@ -163,6 +164,7 @@ exports.config = {
          'javascripts/whole-vendor.js': TRAVIS ? [
-           regJoin('^vendor/scripts/(?!(Box2d|jasmine|register-game-libraries))'),
+-          regJoin('^vendor/scripts/(?!(Box2d|jasmine|register-game-libraries))'),
++          regJoin('^vendor/scripts/(?!(Box2d|jasmine|polyfill|register-game-libraries))'),
            regJoin('^bower_components/(?!aether|esper.js)'),
-+          'node_modules/babel-polyfill/polyfill.js',
          ] : [],
 
-         // - Other vendor libraries in separate bunches
-@@ -186,6 +188,7 @@ exports.config = {
+@@ -186,6 +186,7 @@ exports.config = {
          'javascripts/app/vendor/coffeescript.js': 'vendor/scripts/coffeescript.js',
          'javascripts/app/vendor/difflib.js': 'vendor/scripts/difflib.js',
          'javascripts/app/vendor/diffview.js': 'vendor/scripts/diffview.js',
-+        'javascripts/app/vendor/polyfill.js': 'node_modules/babel-polyfill/polyfill.js',
++        'javascripts/app/vendor/polyfill.js': 'vendor/scripts/polyfill.js',
          'javascripts/app/vendor/treema.js': 'bower_components/treema/treema.js',
          'javascripts/app/vendor/jasmine-bundle.js': regJoin('^vendor/scripts/jasmine'),
          'javascripts/app/vendor/jasmine-mock-ajax.js': 'vendor/scripts/jasmine-mock-ajax.js',
-@@ -265,6 +268,9 @@ exports.config = {
+@@ -265,6 +266,9 @@ exports.config = {
    framework: 'backbone',
 
    plugins: {
@@ -98,7 +100,7 @@ index 561b02868..6595249a8 100644
      coffeelint: {
        pattern: /^app\/.*\.coffee$/,
        options: {
-@@ -319,6 +325,7 @@ exports.config = {
+@@ -319,6 +323,7 @@ exports.config = {
 
  const dirStack = ['./app'];
  const coffeeFiles = [];
@@ -106,7 +108,7 @@ index 561b02868..6595249a8 100644
  const jadeFiles = [];
 
  while (dirStack.length) {
-@@ -331,6 +338,8 @@ while (dirStack.length) {
+@@ -331,6 +336,8 @@ while (dirStack.length) {
        dirStack.push(fullPath);
      } else if (_.str.endsWith(file, '.coffee')) {
        coffeeFiles.push(fullPath);
@@ -115,7 +117,7 @@ index 561b02868..6595249a8 100644
      } else if (_.str.endsWith(file, '.jade')) {
        jadeFiles.push(fullPath);
      }
-@@ -343,6 +352,12 @@ for (file of Array.from(coffeeFiles)) {
+@@ -343,6 +350,12 @@ for (file of Array.from(coffeeFiles)) {
    exports.config.files.javascripts.joinTo[outputFile] = inputFile;
  }
 
@@ -128,7 +130,7 @@ index 561b02868..6595249a8 100644
  let numBundles = 0;
 
  for (file of Array.from(jadeFiles)) {
-@@ -361,7 +376,7 @@ for (file of Array.from(jadeFiles)) {
+@@ -361,7 +374,7 @@ for (file of Array.from(jadeFiles)) {
    }
  }
 
@@ -149,8 +151,20 @@ index 3abc77f62..71f6d4a95 100644
 +require('babel-polyfill');
  var server = require('./server');
  server.startServer();
+diff --git a/karma.conf.js b/karma.conf.js
+index c7ed0175d..f37e98f09 100644
+--- a/karma.conf.js
++++ b/karma.conf.js
+@@ -15,6 +15,7 @@ module.exports = function(config) {
+       'public/javascripts/aether.js',
+       'public/javascripts/whole-app.js',
+       'public/javascripts/app/vendor/jasmine-mock-ajax.js',
++      'public/javascripts/app/vendor/polyfill.js',
+       'public/javascripts/app/tests.js',
+       'public/javascripts/run-tests.js'
+     ],
 diff --git a/package.json b/package.json
-index 3af818a55..c3985f132 100644
+index 8972e4601..6f2e726ba 100644
 --- a/package.json
 +++ b/package.json
 @@ -33,10 +33,10 @@
@@ -180,3 +194,11 @@ index c7e01170a..6d9c7d9c9 100644
 
  var oldIt = global.it;
  global.it = function(description, testFn) {
+diff --git a/vendor/scripts/polyfill.js b/vendor/scripts/polyfill.js
+new file mode 120000
+index 000000000..0f0c30236
+--- /dev/null
++++ b/vendor/scripts/polyfill.js
+@@ -0,0 +1 @@
++../../node_modules/babel-polyfill/dist/polyfill.js
+\ No newline at end of file


### PR DESCRIPTION
New strategy is to symlink to node_modules, since it looks like brunch can't
pick it up directly from there.

Also remove -x since it was super-noisy.