### PR TITLE
Don't run bower_components through babel for codecombat

### DIFF
--- a/examples/codecombat/decaffeinate.patch
+++ b/examples/codecombat/decaffeinate.patch
@@ -1,5 +1,19 @@
+diff --git a/.babelrc b/.babelrc
+index 164185f69..4275f9e0b 100644
+--- a/.babelrc
++++ b/.babelrc
+@@ -3,5 +3,8 @@
+   "plugins": ["transform-remove-strict-mode"],
+   "parserOpts": {
+     "allowReturnOutsideFunction": true
+-  }
++  },
++  "ignore": [
++    "bower_components"
++  ]
+ }
 diff --git a/app/views/TestView.js b/app/views/TestView.js
-index fdf720fa4..8317569a6 100644
+index 8c6f3bded..a758edb40 100644
 --- a/app/views/TestView.js
 +++ b/app/views/TestView.js
 @@ -23,6 +23,7 @@ const template = require('templates/test-view');


### PR DESCRIPTION
Apparently the last remaining test failure is some issue with babel running on
the esper.modern.js file, so hopefully disabling babel will fix it (as well as
being a good idea anyway).