### PR TITLE
Fix error handling

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -27,8 +27,8 @@ async function runCli(project, shouldPublish) {
       await testProject(project, shouldPublish);
     }
   } catch (e) {
-    console.error(`ERROR: ${e.message}`);
     process.exitCode = 1;
+    console.error(`ERROR: ${e.message}`);
   }
 }
 

--- a/src/run.js
+++ b/src/run.js
@@ -15,7 +15,7 @@ export default function run(command) {
       if (code === 0) {
         resolve();
       } else {
-        reject();
+        reject(new Error(`Command failed: ${command}`));
       }
     });
   });


### PR DESCRIPTION
Previously, if there was no message, we would crash before setting the exit
status. Now, set the exit status ASAP and also make sure to always send up a
message.