### PR TITLE
Add eslint-plugin-node as a dependency for atom

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -4,6 +4,7 @@ export default {
   useDefaultConfig: true,
   extraDependencies: [
     'eslint-config-standard',
+    'eslint-plugin-node',
     'eslint-plugin-promise',
     'eslint-plugin-standard',
   ],


### PR DESCRIPTION
The most recent version of standard requires it now.