### PR TITLE
Avoid running decaffeinate multiple times for each file

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -19,5 +19,5 @@ export default {
     script/test
   `,
   expectConversionSuccess: true,
-  expectTestSuccess: false,
+  expectTestSuccess: true,
 };

--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -30,5 +30,5 @@ export default {
     npm run jasmine
   `,
   expectConversionSuccess: true,
-  expectTestSuccess: false,
+  expectTestSuccess: true,
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -108,9 +108,9 @@ async function testProject(project, shouldPublish) {
     await run('git add -A');
     await run('git commit -m "Save decaffeinate error details"');
 
-    await run('bulk-decaffeinate convert -p decaffeinate-successful-files.txt');
+    await run('bulk-decaffeinate convert --skip-verify -p decaffeinate-successful-files.txt');
   } else {
-    await run('bulk-decaffeinate convert');
+    await run('bulk-decaffeinate convert --skip-verify');
   }
 
   await run('bulk-decaffeinate clean');
@@ -165,6 +165,13 @@ function getDependencies(config) {
 }
 
 async function checkConversion(config) {
+  // To reduce build times, skip the check step if we expect success. If there
+  // is a problem later, it will end up as a crash and the build will fail.
+  if (config.expectConversionSuccess) {
+    return {
+      passed: true,
+    };
+  }
   await run('bulk-decaffeinate check');
   let hasErrorFile = await exists('./decaffeinate-errors.log');
   if (hasErrorFile) {


### PR DESCRIPTION
We don't need to verify during convert since there's already a check step
earlier. Also, if we expect all files to convert, we can just skip the check
step and let the build fail in an uglier way. If it does fail, we'll have to
change `expectConversionSuccess` to false or fix the failure.