### PR TITLE
Pin autoprefixer version to 6.7.7

### DIFF
--- a/examples/autoprefixer/config.js
+++ b/examples/autoprefixer/config.js
@@ -1,6 +1,7 @@
 export default {
   cloneUrl: 'https://github.com/postcss/autoprefixer.git',
   forkUrl: 'git@github.com:decaffeinate-examples/autoprefixer.git',
+  branch: '6.7.7',
   useDefaultConfig: true,
   expectConversionSuccess: true,
   expectTestSuccess: true,


### PR DESCRIPTION
Version 7.0.0 is now JavaScript thanks to decaffeinate! So we'll just run the
build on the last version before the switch to JS.