### PR TITLE
Change run command to always show timing information

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -8,16 +8,16 @@ export default {
     'eslint-plugin-promise',
     'eslint-plugin-standard',
   ],
-  testCommand: `
-    set -e
-    rm -rf node_modules
-    export NODE_VERSION=6.9.4 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
+  testCommands: [
+    'rm -rf node_modules',
+    `
     if [ -e /sbin/start-stop-daemon ]; then
       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     fi
-    script/build --create-debian-package --create-rpm-package --compress-artifacts
-    script/test
-  `,
+    `,
+    'script/build --create-debian-package --create-rpm-package --compress-artifacts',
+    'script/test',
+  ],
   expectConversionSuccess: true,
   expectTestSuccess: true,
 };

--- a/examples/chroma.js/config.js
+++ b/examples/chroma.js/config.js
@@ -7,7 +7,7 @@ export default {
   ],
   expectConversionSuccess: true,
   expectTestSuccess: true,
-  testCommand: `
+  testCommands: [`
     set -e
     find src -name '*.js' | xargs sed -i -e 's/\\/\\/ @require\\(.*\\)$/\\/* @require\\1 *\\//g'
     git commit -a -m 'Change catty dependencies to have the proper format'
@@ -15,5 +15,5 @@ export default {
     npm run build
     git commit -a -m 'Rebuild chroma.js'
     npm test
-  `,
+  `],
 };

--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -6,7 +6,7 @@ export default {
     'babel-plugin-transform-remove-strict-mode',
     'babel-brunch@6.0.0',
   ],
-  testCommand: `
+  testCommands: [`
     set -e
     export COCO_TRAVIS_TEST=1
     export DISPLAY=:99.0
@@ -28,7 +28,7 @@ export default {
     
     ./node_modules/karma/bin/karma start --browsers Firefox --single-run --reporters dots
     npm run jasmine
-  `,
+  `],
   expectConversionSuccess: true,
   expectTestSuccess: true,
 };

--- a/examples/coffeescript/config.js
+++ b/examples/coffeescript/config.js
@@ -7,13 +7,13 @@ export default {
     'babel-plugin-transform-remove-strict-mode',
     'js-cake',
   ],
-  testCommand: `
+  testCommands: [`
     set -e
     ./node_modules/.bin/babel src -d lib/coffee-script
     git commit -a -m 'Rebuild CoffeeScript with new code'
     ./check-coffeescript-examples.sh
     ./node_modules/.bin/js-cake test
-  `,
+  `],
   expectConversionSuccess: true,
   expectTestSuccess: false,
 };

--- a/examples/vimium/config.js
+++ b/examples/vimium/config.js
@@ -18,12 +18,12 @@ export default {
     done
     git commit -m 'Move source files to src directory'
   `,
-  testCommand: `
+  testCommands: [`
     set -e
     git submodule update --init
     npm install path@0.11
     npm install util
     ./node_modules/.bin/js-cake build
     ./node_modules/.bin/js-cake test
-  `,
+  `],
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "author": "Alan Pierce",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "babel-eslint": "^7.1.1",
     "babel-polyfill": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
@@ -15,6 +15,8 @@
     "commander": "^2.9.0",
     "eslint": "^3.14.1",
     "eslint-plugin-babel": "^4.0.1",
+    "moment": "^2.18.1",
+    "moment-precise-range-plugin": "^1.2.1",
     "mz": "^2.6.0"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -214,8 +214,10 @@ async function runTests(config) {
     return 'SKIPPED';
   }
   try {
-    if (config.testCommand) {
-      await run(config.testCommand);
+    if (config.testCommands) {
+      for (let command of config.testCommands) {
+        await run(command);
+      }
     } else {
       await run('npm test');
     }

--- a/src/run.js
+++ b/src/run.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+import 'moment-precise-range-plugin';
 import { spawn } from 'child_process';
 
 /**
@@ -8,10 +10,13 @@ import { spawn } from 'child_process';
  * Taken directly from execLive in bulk-decaffeinate.
  */
 export default function run(command) {
+  let startTime = moment();
+  console.log(`Time: ${startTime.format()}`);
   console.log(`> ${command}`);
   return new Promise((resolve, reject) => {
     let childProcess = spawn('/bin/bash', ['-c', command], {stdio: 'inherit'});
     childProcess.on('close', code => {
+      console.log(`Time taken: ${startTime.preciseDiff() || '0 seconds'}`);
       if (code === 0) {
         resolve();
       } else {


### PR DESCRIPTION
Also split the test command up into multiple run commands when possible.

This should help figure out the highest-value parts of the atom build to
optimize.