### PR TITLE
Skip package creation in the atom build

### DIFF
--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -15,7 +15,7 @@ export default {
       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     fi
     `,
-    'script/build --create-debian-package --create-rpm-package --compress-artifacts',
+    'script/build',
     'script/test',
   ],
   expectConversionSuccess: true,


### PR DESCRIPTION
Just the atom build step is taking 35 minutes, so hopefully getting rid of this
part will still work and speed things up.