### PR TITLE
Add `root: true` to all eslintrc files

### DIFF
--- a/default-config/.eslintrc.js
+++ b/default-config/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "root": true,
   "extends": "airbnb-base",
   "plugins": [
     "import"

--- a/examples/atom-org/.eslintrc.js
+++ b/examples/atom-org/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "root": true,
   "extends": "standard",
   "plugins": [
     "standard",

--- a/examples/atom/.eslintrc.js
+++ b/examples/atom/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "root": true,
   "extends": "standard",
   "plugins": [
     "standard",

--- a/examples/coffeelint/.eslintrc.js
+++ b/examples/coffeelint/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "root": true,
   "extends": "airbnb-base",
   "plugins": [
     "import"


### PR DESCRIPTION
This avoids eslint pulling in rules from the parent decaffeinate-examples
project.