### PR TITLE
Fix codecombat build

### DIFF
--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -13,12 +13,6 @@ export default {
     if [ -e /etc/init.d/xvfb ]; then
       sh -e /etc/init.d/xvfb start
     fi
-    if [ -e ~/.nvm/nvm.sh ]; then
-      source ~/.nvm/nvm.sh
-    fi
-    nvm install 5.1.1
-    rm -rf node_modules
-    rm -rf bower-components
     rm -rf public
     npm install
     

--- a/src/cli.js
+++ b/src/cli.js
@@ -122,7 +122,13 @@ async function testProject(project, shouldPublish, forceCheck) {
     await run(`cat ${exampleDir}/.gitignore_extension >> .gitignore`);
   }
 
-  await run('npm install');
+  try {
+    await run('npm install');
+  } catch (e) {
+    // In some projects, install fails the first time and works the second time,
+    // so just try twice.
+    await run('npm install');
+  }
   let dependencies = getDependencies(config);
   if (dependencies.length > 0) {
     await run(`npm install --save-dev --save-exact ${dependencies.join(' ')}`);


### PR DESCRIPTION
Looks like one of the install dependencies has a script with dependencies that
happen to not be installed at the time anymore, but running install twice works,
so just retry install if it fails the first time. Also get rid of explicit node
5.1.1 install since it's handled in the example builder configuration now.