### PR TITLE
Fix autoprefixer and vimium

### DIFF
--- a/examples/autoprefixer/decaffeinate.patch
+++ b/examples/autoprefixer/decaffeinate.patch
@@ -1,7 +1,7 @@
-diff --git a/gulpfile.js b/gulpfile.js
+diff --git c/gulpfile.js w/gulpfile.js
 index c775c97..ec8d3f9 100644
---- a/gulpfile.js
-+++ b/gulpfile.js
+--- c/gulpfile.js
++++ w/gulpfile.js
 @@ -1,3 +1,4 @@
 +/* eslint-disable */
  var gulp = require('gulp');
@@ -28,3 +28,16 @@ index c775c97..ec8d3f9 100644
  });
 
  gulp.task('default', ['lint', 'test']);
+diff --git c/package.json w/package.json
+index 2d253c0..b10a354 100644
+--- c/package.json
++++ w/package.json
+@@ -43,7 +43,7 @@
+     "vinyl-source-stream": "^1.1.0"
+   },
+   "scripts": {
+-    "test": "gulp"
++    "test": "gulp test"
+   },
+   "eslintConfig": {
+     "extends": "eslint-config-postcss/es5"

--- a/examples/vimium/decaffeinate.patch
+++ b/examples/vimium/decaffeinate.patch
@@ -1,10 +1,10 @@
-diff --git a/Cakefile.js b/Cakefile.js
-index 9c7cfa1..b7f6b66 100644
---- a/Cakefile.js
-+++ b/Cakefile.js
-@@ -75,8 +75,17 @@ var visitDirectory = (directory, visitor) =>
- ;
-
+diff --git i/Cakefile.js w/Cakefile.js
+index 63532f7..39c3036 100644
+--- i/Cakefile.js
++++ w/Cakefile.js
+@@ -81,8 +81,17 @@ var visitDirectory = (directory, visitor) =>
+     return visitor(filepath);
+   });
  task('build', 'compile all coffeescript files to javascript', () => {
 -  const coffee = spawn('coffee', ['-c', __dirname]);
 -  return coffee.on('exit', returnCode => process.exit(returnCode));
@@ -22,10 +22,10 @@ index 9c7cfa1..b7f6b66 100644
  });
 
  task('clean', 'removes any js files which were compiled from coffeescript', () =>
-diff --git a/pages/hud.html b/pages/hud.html
+diff --git i/pages/hud.html w/pages/hud.html
 index 9532afc..4acf507 100644
---- a/pages/hud.html
-+++ b/pages/hud.html
+--- i/pages/hud.html
++++ w/pages/hud.html
 @@ -2,6 +2,7 @@
    <head>
      <title>HUD</title>
@@ -34,10 +34,10 @@ index 9532afc..4acf507 100644
      <script type="text/javascript" src="../lib/utils.js"></script>
      <script type="text/javascript" src="../lib/dom_utils.js"></script>
      <script type="text/javascript" src="../lib/keyboard_utils.js"></script>
-diff --git a/pages/vomnibar.html b/pages/vomnibar.html
+diff --git i/pages/vomnibar.html w/pages/vomnibar.html
 index 87acc08..392c03f 100644
---- a/pages/vomnibar.html
-+++ b/pages/vomnibar.html
+--- i/pages/vomnibar.html
++++ w/pages/vomnibar.html
 @@ -1,6 +1,7 @@
  <html>
    <head>
@@ -46,10 +46,10 @@ index 87acc08..392c03f 100644
      <script type="text/javascript" src="../lib/utils.js"></script>
      <script type="text/javascript" src="../lib/keyboard_utils.js"></script>
      <script type="text/javascript" src="../lib/dom_utils.js"></script>
-diff --git a/tests/dom_tests/dom_tests.html b/tests/dom_tests/dom_tests.html
+diff --git i/tests/dom_tests/dom_tests.html w/tests/dom_tests/dom_tests.html
 index d2e795d..78a7e77 100644
---- a/tests/dom_tests/dom_tests.html
-+++ b/tests/dom_tests/dom_tests.html
+--- i/tests/dom_tests/dom_tests.html
++++ w/tests/dom_tests/dom_tests.html
 @@ -29,6 +29,7 @@
      <link rel="stylesheet" type="text/css" href="../../content_scripts/vimium.css" />
      <script type="text/javascript" src="bind.js"></script>


### PR DESCRIPTION
Autoprefixer runs lint as part of its test suite, but the eslint config wasn't
matching the old eslint version installed by the gulp plugin. Fixed by no longer
running lint.

Vimium had a slightly out of date patch file, I think due to a change in eslint
autofixing.