### PR TITLE
Pin atom to an old version

### DIFF
--- a/examples/atom-org/config.js
+++ b/examples/atom-org/config.js
@@ -4,7 +4,7 @@ export default {
     {url: 'https://github.com/atom/apm.git', name: 'apm'},
     {url: 'https://github.com/atom/archive-view.git', name: 'archive-view'},
     {url: 'https://github.com/atom/ascii-art.git', name: 'ascii-art'},
-    {url: 'https://github.com/atom/atom.git', name: 'atom'},
+    {url: 'https://github.com/atom/atom.git', name: 'atom', branch: 'v1.20.0'},
     {url: 'https://github.com/atom/atom-keymap.git', name: 'atom-keymap'},
     {url: 'https://github.com/atom/atom-selector-linter.git', name: 'atom-selector-linter'},
     {url: 'https://github.com/atom/atom-space-pen-views.git', name: 'atom-space-pen-views'},

--- a/examples/atom/config.js
+++ b/examples/atom/config.js
@@ -1,5 +1,6 @@
 export default {
   cloneUrl: 'https://github.com/atom/atom.git',
+  branch: 'v1.20.0',
   forkUrl: 'git@github.com:decaffeinate-examples/atom.git',
   useDefaultConfig: true,
   extraDependencies: [

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,8 +64,9 @@ async function testProject(project, shouldPublish, forceCheck) {
   // all CoffeeScript projects in the atom org). In this case, we make a fresh
   // repo with the contents of other cloned repos.
   if (config.isMultiProject) {
-    for (let {url, name} of config.cloneRepos) {
-      await run(`git clone --depth=50 ${url} ${repoDir}/${name}`);
+    for (let {url, branch, name} of config.cloneRepos) {
+      let cloneSuffix = branch ? `--branch ${branch}` : '';
+      await run(`git clone --depth=50 ${cloneSuffix} ${url} ${repoDir}/${name}`);
       await run(`rm -rf ${repoDir}/${name}/.git`);
     }
   } else {


### PR DESCRIPTION
Atom now has a build issue due to having a CoffeeScript and JavaScript test of
the same name, and it now has much more JavaScript than CoffeeScript anyway, so
this pins the version to an older version that tests more CoffeeScript and
doesn't have the duplicate file problem.