### PR TITLE
Expect success for atom-org build

### DIFF
--- a/examples/atom-org/config.js
+++ b/examples/atom-org/config.js
@@ -162,5 +162,6 @@ export default {
     'eslint-plugin-promise',
     'eslint-plugin-standard',
   ],
+  expectConversionSuccess: true,
   skipTests: true,
 };


### PR DESCRIPTION
This should hopefully avoid build timeouts for this build by only running
decaffeinate once.