### PR TITLE
Delete an empty test file in codecombat

### DIFF
--- a/examples/codecombat/decaffeinate.patch
+++ b/examples/codecombat/decaffeinate.patch
@@ -192,9 +192,12 @@ index fb5e780..a94be46 100644
 
  var oldIt = global.it;
  global.it = function(description, testFn) {
+diff --git a/test/app/views/play/level/tome/SpellView.spec.js b/test/app/views/play/level/tome/SpellView.spec.js
+deleted file mode 100644
+index e69de29..0000000
 diff --git a/vendor/scripts/polyfill.js b/vendor/scripts/polyfill.js
 new file mode 120000
-index 000000000..8c2723ed4
+index 0000000..0f0c302
 --- /dev/null
 +++ b/vendor/scripts/polyfill.js
 @@ -0,0 +1 @@


### PR DESCRIPTION
For some reason, the build was failing on an empty file. I don't know what might
have caused this to fail now and work before, but it seems reasonable to just
delete it to get things working.