### PR TITLE
Avoid initial npm install before running decaffeinate

### DIFF
--- a/examples/chroma.js/config.js
+++ b/examples/chroma.js/config.js
@@ -12,6 +12,7 @@ export default {
     find src -name '*.js' | xargs sed -i -e 's/\\/\\/ @require\\(.*\\)$/\\/* @require\\1 *\\//g'
     git commit -a -m 'Change catty dependencies to have the proper format'
     
+    npm install
     npm run build
     git commit -a -m 'Rebuild chroma.js'
     npm test

--- a/examples/coffeescript/config.js
+++ b/examples/coffeescript/config.js
@@ -10,11 +10,12 @@ export default {
   ],
   testCommands: [`
     set -e
+    npm install
     ./node_modules/.bin/babel src -d lib/coffee-script
     git commit -a -m 'Rebuild CoffeeScript with new code'
     ./check-coffeescript-examples.sh
     ./node_modules/.bin/js-cake test
   `],
   expectConversionSuccess: true,
-  expectTestSuccess: false,
+  expectTestSuccess: true,
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -125,16 +125,9 @@ async function testProject(project, shouldPublish, forceCheck) {
     await run(`cat ${exampleDir}/.gitignore_extension >> .gitignore`);
   }
 
-  try {
-    await run('npm install');
-  } catch (e) {
-    // In some projects, install fails the first time and works the second time,
-    // so just try twice.
-    await run('npm install');
-  }
   let dependencies = getDependencies(config);
   if (dependencies.length > 0) {
-    await run(`npm install --save-dev --save-exact ${dependencies.join(' ')}`);
+    await run(`npm install --save-dev --save-exact --ignore-scripts ${dependencies.join(' ')}`);
   }
   await run('git add -A');
   await run('git commit --no-verify -m "Add dependencies and config to prepare for decaffeinate"');
@@ -272,6 +265,7 @@ async function runTests(config) {
         await run(command);
       }
     } else {
+      await run('npm install');
       await run('npm test');
     }
     return 'PASSED';


### PR DESCRIPTION
This was causing issues for codecombat, and generally it seems nicer to only
install once rather than before and after. This might cause some projects to
break, but I can iterate on those, and the ones I tested seem fine.

Also change CoffeeScript config to expect the test suite to pass.