### PR TITLE
Try "npm install" twice for codecombat

### DIFF
--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -14,7 +14,8 @@ export default {
       sh -e /etc/init.d/xvfb start
     fi
     rm -rf public
-    npm install
+    # Some dependency issues make the install fail the first time, so just try again.
+    npm install || npm install
     
     node index.js --unittest &
     n=0


### PR DESCRIPTION
It seems to fail the first time due to an error in an install script, presumably
due to an ordering issue. Just like in the old system, we can just try again.