### PR TITLE
Fix more install issues with codecombat

### DIFF
--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -16,6 +16,11 @@ export default {
     rm -rf public
     # Some dependency issues make the install fail the first time, so just try again.
     npm install || npm install
+    # node-sass doesn't get set up correctly for some reason, so set it up again.
+    npm install node-sass
+    
+    ./node_modules/.bin/bower install
+    ./node_modules/.bin/webpack
     
     node index.js --unittest &
     n=0

--- a/examples/codecombat/decaffeinate.patch
+++ b/examples/codecombat/decaffeinate.patch
@@ -37,6 +37,18 @@ index e008887..d10ebdf 100644
 
      transports: ['polling'],
 
+diff --git a/package.json b/package.json
+index 2d78ee9..b42d8fe 100644
+--- a/package.json
++++ b/package.json
+@@ -33,7 +33,6 @@
+     "test": "./node_modules/.bin/karma start",
+     "predeploy": "echo Starting deployment--hold onto your butts.; echo Skipping brunch build --production",
+     "postdeploy": "echo Deployed. Unclench.",
+-    "postinstall": "bower install && webpack",
+     "webpack": "webpack",
+     "bower": "bower",
+     "dev": "webpack --watch & npm run nodemon",
 diff --git a/spec/helpers/helper.js b/spec/helpers/helper.js
 index fb5e780..a94be46 100644
 --- a/spec/helpers/helper.js


### PR DESCRIPTION
It looks like node-sass needs to be reinstalled to properly run the install
script, so do that, and explicitly run the postinstall steps rather than them
being in package.json.