### PR TITLE
Make babel ignored files more precise

### DIFF
--- a/examples/codecombat/decaffeinate.patch
+++ b/examples/codecombat/decaffeinate.patch
@@ -1,5 +1,5 @@
 diff --git a/.babelrc b/.babelrc
-index 164185f..e893dc3 100644
+index 164185f69..39029544a 100644
 --- a/.babelrc
 +++ b/.babelrc
 @@ -3,5 +3,9 @@
@@ -9,12 +9,12 @@ index 164185f..e893dc3 100644
 -  }
 +  },
 +  "ignore": [
-+    "bower_components",
-+    "vendor"
++    "./bower_components/**/*.js",
++    "./vendor/**/*.js"
 +  ]
  }
 diff --git a/app/app.js b/app/app.js
-index 90066c7..3dd1319 100644
+index 90066c7f7..3dd131934 100644
 --- a/app/app.js
 +++ b/app/app.js
 @@ -2,6 +2,7 @@ global.$ = window.$ = global.jQuery = window.jQuery = require('jquery');
@@ -26,7 +26,7 @@ index 90066c7..3dd1319 100644
 
  // require.context('app/schemas', true, /.*\.(coffee|jade)/)
 diff --git a/app/assets/javascripts/run-tests.js b/app/assets/javascripts/run-tests.js
-index 953f67e..d6a69d7 100644
+index 953f67e42..d6a69d7bc 100644
 --- a/app/assets/javascripts/run-tests.js
 +++ b/app/assets/javascripts/run-tests.js
 @@ -1,5 +1,6 @@
@@ -37,7 +37,7 @@ index 953f67e..d6a69d7 100644
 
  window.userObject = {_id:'1'};
 diff --git a/index.js b/index.js
-index 3abc77f..71f6d4a 100644
+index 3abc77f62..71f6d4a95 100644
 --- a/index.js
 +++ b/index.js
 @@ -8,5 +8,7 @@ if (majorVersion === 4) {
@@ -49,7 +49,7 @@ index 3abc77f..71f6d4a 100644
  var server = require('./server');
  server.startServer();
 diff --git a/karma.conf.js b/karma.conf.js
-index e008887..d10ebdf 100644
+index e008887fa..d10ebdf1d 100644
 --- a/karma.conf.js
 +++ b/karma.conf.js
 @@ -60,7 +60,7 @@ module.exports = function(config) {
@@ -62,7 +62,7 @@ index e008887..d10ebdf 100644
      transports: ['polling'],
 
 diff --git a/package.json b/package.json
-index 2d78ee9..b42d8fe 100644
+index 2d78ee9a9..b42d8feaa 100644
 --- a/package.json
 +++ b/package.json
 @@ -33,7 +33,6 @@
@@ -74,7 +74,7 @@ index 2d78ee9..b42d8fe 100644
      "bower": "bower",
      "dev": "webpack --watch & npm run nodemon",
 diff --git a/spec/helpers/helper.js b/spec/helpers/helper.js
-index fb5e780..a94be46 100644
+index fb5e78004..a94be4631 100644
 --- a/spec/helpers/helper.js
 +++ b/spec/helpers/helper.js
 @@ -2,6 +2,8 @@ var _ = require('lodash');
@@ -87,7 +87,7 @@ index fb5e780..a94be46 100644
  var oldIt = global.it;
  global.it = function(description, testFn) {
 diff --git a/webpack.base.config.js b/webpack.base.config.js
-index b0959b4..65d8597 100644
+index b0959b487..65d859731 100644
 --- a/webpack.base.config.js
 +++ b/webpack.base.config.js
 @@ -8,6 +8,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');


### PR DESCRIPTION
It looks like babel was ignoring test/app/vendorTests/lodash.spec.js, so
hopefully the more precise globs will work better.