### PR TITLE
Allow codecombat to run through decaffeinate on recent node

### DIFF
--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -6,7 +6,8 @@ export default {
     'babel-plugin-transform-remove-strict-mode',
     'babel-loader',
   ],
-  testCommands: [`
+  testCommands: [
+    `
     set -e
     export COCO_TRAVIS_TEST=1
     export DISPLAY=:99.0
@@ -14,25 +15,23 @@ export default {
       sh -e /etc/init.d/xvfb start
     fi
     rm -rf public
-    # Some dependency issues make the install fail the first time, so just try again.
-    npm install || npm install
-    # node-sass doesn't get set up correctly for some reason, so set it up again.
-    npm install node-sass
-    npm install request
-    
-    ./node_modules/.bin/bower install
-    ./node_modules/.bin/webpack
-    
-    git add -f public/javascripts/test.js
-    git commit -m 'Save bad built JS file for diagnostic purposes'
-    
-    node index.js --unittest &
+    `,
+    'nvm install 5.10.1',
+    // Some dependency issues make the install fail the first time, so just try again.
+    'npm install || npm install',
+    // node-sass doesn't get set up correctly for some reason, so set it up again.
+    'npm install node-sass',
+    'npm install request',
+    './node_modules/.bin/bower install',
+    './node_modules/.bin/webpack',
+    'node index.js --unittest &',
+    `
     n=0
     until [ $n -ge 60 ]; do curl http://localhost:3000 && break; n=$[$n+1]; sleep 1; done
-    
-    ./node_modules/karma/bin/karma start --browsers Firefox --single-run --reporters dots
-    npm run jasmine
-  `],
+    `,
+    './node_modules/karma/bin/karma start --browsers Firefox --single-run --reporters dots',
+    'npm run jasmine',
+  ],
   expectConversionSuccess: true,
   expectTestSuccess: true,
 };


### PR DESCRIPTION
It looks like running decaffeinate in node 8 will probably save a few minutes
from the build and hopefully make it much less likely to time out. Also split
the config up into multiple commands so it's easier to see timing information.