### PR TITLE
Run codecombat on node 6

### DIFF
--- a/examples/codecombat/config.js
+++ b/examples/codecombat/config.js
@@ -16,7 +16,7 @@ export default {
     rm -rf public
     rm -rf ./node_modules
     source ~/.nvm/nvm.sh
-    nvm install 5.10.1
+    nvm install 6.12.2
     # Some dependency issues make the install fail the first time, so just try again.
     time npm install || npm install
     # node-sass doesn't get set up correctly for some reason, so set it up again.


### PR DESCRIPTION
This might fix the syntax error problems showing up now, and at least will get
closer to the upstream build config.