### PR TITLE
Use yarn instead of npm when a yarn.lock file exists

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -265,7 +265,12 @@ async function runTests(config) {
         await run(command);
       }
     } else {
-      await run('npm install');
+      if (await exists('./yarn.lock')) {
+        await run('npm install -g yarn');
+        await run('yarn');
+      } else {
+        await run('npm install');
+      }
       await run('npm test');
     }
     return 'PASSED';


### PR DESCRIPTION
Autoprefixer had a yarn.lock, particularly to pin the caniuse dependency, but we
were using npm, so it wasn't being respected and an upgrade broke tests. Now we
install with yarn if we see a yarn.lock so that tests are more reliable.