### PR TITLE
Don't transform codecombat dynamicRequire.js

### DIFF
--- a/examples/codecombat/decaffeinate.patch
+++ b/examples/codecombat/decaffeinate.patch
@@ -123,7 +123,7 @@ index 192f8de..c345e98 100644
          { test: /\.coffee$/, use: [
            { loader: 'coffee-loader' },
          ] },
-+        { test: /\.js$/, exclude: /node_modules/, use: [
++        { test: /\.js$/, exclude: /node_modules|dynamicRequire\.js/, use: [
 +            { loader: 'babel-loader' },
 +          ] },
          { test: /\.jade$/, use: { loader: 'jade-loader', options: { root: path.resolve('./app') } } },


### PR DESCRIPTION
Currently Babel crashes when trying to compile it, but really we don't want it
attempting to compile the dynamic `import` at all, since the intention is for
webpack to handle it.