### PR TITLE
Bump autocomplete-plus dependency to latest to fix atom build

### DIFF
--- a/examples/atom/decaffeinate.patch
+++ b/examples/atom/decaffeinate.patch
@@ -1,8 +1,21 @@
+diff --git a/package.json b/package.json
+index 657a0b2..2339d14 100644
+--- a/package.json
++++ b/package.json
+@@ -92,7 +92,7 @@
+     "autocomplete-atom-api": "0.10.2",
+     "autocomplete-css": "0.17.2",
+     "autocomplete-html": "0.8.0",
+-    "autocomplete-plus": "2.35.7",
++    "autocomplete-plus": "2.40.2",
+     "autocomplete-snippets": "1.11.0",
+     "autoflow": "0.29.0",
+     "autosave": "0.24.3",
 diff --git a/spec/compile-cache-spec.js b/spec/compile-cache-spec.js
-index 246efe2..958f281 100644
+index 530e6e0..7af4951 100644
 --- a/spec/compile-cache-spec.js
 +++ b/spec/compile-cache-spec.js
-@@ -108,7 +108,7 @@ describe('CompileCache', function () {
+@@ -114,7 +114,7 @@ describe('CompileCache', function () {
        waits(1)
        return runs(function () {
          error = new Error('Oops again')
@@ -11,7 +24,7 @@ index 246efe2..958f281 100644
          return expect(Array.isArray(error.getRawStack())).toBe(true)
        })
      })
-@@ -120,7 +120,7 @@ describe('CompileCache', function () {
+@@ -126,7 +126,7 @@ describe('CompileCache', function () {
        Error.prepareStackTrace = originalPrepareStackTrace
 
        const error = new Error('Oops')
@@ -20,7 +33,7 @@ index 246efe2..958f281 100644
        return expect(Array.isArray(error.getRawStack())).toBe(true)
      })
 
-@@ -133,7 +133,7 @@ describe('CompileCache', function () {
+@@ -139,7 +139,7 @@ describe('CompileCache', function () {
        }
 
        const error = new Error('Oops')
@@ -30,10 +43,10 @@ index 246efe2..958f281 100644
        return expect(Array.isArray(error.getRawStack())).toBe(true)
      })
 diff --git a/spec/config-spec.js b/spec/config-spec.js
-index ac5db8e..7566278 100644
+index bd15672..b87615e 100644
 --- a/spec/config-spec.js
 +++ b/spec/config-spec.js
-@@ -1310,7 +1310,7 @@ foo:
+@@ -1317,7 +1317,7 @@ foo:
              expect(fs.existsSync(atom.config.configDirPath)).toBeTruthy()
              expect(fs.existsSync(path.join(atom.config.configDirPath, 'packages'))).toBeTruthy()
              expect(fs.isFileSync(path.join(atom.config.configDirPath, 'snippets.cson'))).toBeTruthy()
@@ -43,10 +56,10 @@ index ac5db8e..7566278 100644
            })
          })
 diff --git a/spec/integration/helpers/start-atom.js b/spec/integration/helpers/start-atom.js
-index 6d5b6bb..795296d 100644
+index 69927f1..9f25aee 100644
 --- a/spec/integration/helpers/start-atom.js
 +++ b/spec/integration/helpers/start-atom.js
-@@ -103,7 +103,12 @@ const buildAtomClient = function (args, env) {
+@@ -111,7 +111,12 @@ const buildAtomClient = function (args, env) {
          .windowHandles(cb)
      }).addCommand('waitForPaneItemCount', function (count, timeout, cb) {
        return this.waitUntil(function () {


### PR DESCRIPTION
This is a stopgap until apm supports installing older package versions.
Hopefully this is the only one that has had enough versions published to cause a
problem.