### PR TITLE
Pin CoffeeScript2 to 2.2.1

### DIFF
--- a/examples/coffeescript2/config.js
+++ b/examples/coffeescript2/config.js
@@ -1,6 +1,7 @@
 export default {
   cloneUrl: 'https://github.com/jashkenas/coffeescript.git',
   forkUrl: 'git@github.com:decaffeinate-examples/coffeescript2.git',
+  branch: '2.2.1',
   useDefaultConfig: true,
   extraDependencies: [
     'babel-plugin-transform-remove-strict-mode',

--- a/examples/coffeescript2/decaffeinate.patch
+++ b/examples/coffeescript2/decaffeinate.patch
@@ -36,7 +36,7 @@ index 0000000..5d768d2
 @@ -0,0 +1,20 @@
 +#!/bin/bash
 +
-+# Simple shell script to compare the decaffeinated CoffeeScript compiler
++# Simple shell script to compare the decaffeinated CoffeeScript 2.2.1 compiler
 +# with the official one, running it on all CoffeeScript files in the repo and
 +# making sure the output is the same. For now, it just fails on the first error.
 +
@@ -45,7 +45,7 @@ index 0000000..5d768d2
 +rm -rf examples-tmp
 +mkdir examples-tmp
 +cd examples-tmp
-+git clone https://github.com/jashkenas/coffeescript.git
++git clone https://github.com/jashkenas/coffeescript.git --branch 2.2.1
 +
 +for path in $(find coffeescript -name '*.coffee'); do
 +  echo "Comparing ${path}..."


### PR DESCRIPTION
Previously, it was taking the latest code, but there have been recent syntax bug
fixes with test cases, and naturally those won't be handled by decaffeinate
until it updates to the most recent parser.